### PR TITLE
Update Omnistrate CTL Formula to v0.13.25

### DIFF
--- a/Formula/omnistrate-ctl.rb
+++ b/Formula/omnistrate-ctl.rb
@@ -1,12 +1,12 @@
 class OmnistrateCtl < Formula
     desc "Omnistrate CTL command line tool"
     homepage "https://omnistrate.com"
-    version "v0.13.12"
+    version "v0.13.25"
     
-    sha_darwin_amd64 = "57135df53b347d4a99edee5c4be89aa4965bd1eea9ba07975ad8d823e69336e2"
-    sha_darwin_arm64 = "0211138aaaaa48db5529efd85e5dca6c4a3fe6165a2655ab900a36c4bff453e7"
-    sha_linux_amd64 = "c87bbcaa9954fbbb653cc02c8eaf17d9d8cb064fd570b2c9d5c3ae2900e5e2ae"
-    sha_linux_arm64 = "e6119d4a45eb99d0ba330c132d9b2def71faaede2251de65621993aacf7efb14"
+    sha_darwin_amd64 = "009b573a1ed76ed04926d01458a19ba0bcb439da0a90e4e1d861c16342dbaeb5"
+    sha_darwin_arm64 = "c772184426e843e0d077f587e3499a4ba0593420d9200a9cf2900d63be0727ca"
+    sha_linux_amd64 = "012790a9acab62f4081d145e8c9ae000c0aa654f8652270b595a5e50c5bb0668"
+    sha_linux_arm64 = "e8eb79d19d3f1ab0fb9b141c9d6e5eeb2af4aa58fa60510169ce18292cd8c2f1"
 
     if OS.mac?
       if Hardware::CPU.intel?


### PR DESCRIPTION
This PR updates the Omnistrate CTL Formula to version v0.13.25.
The SHA256 checksums have been updated as well.
Once the PR is merged, the new version will be available in the Omnistrate Homebrew Tap.