### PR TITLE
Update Omnistrate CTL Formula to v0.13.31

### DIFF
--- a/Formula/omnistrate-ctl.rb
+++ b/Formula/omnistrate-ctl.rb
@@ -1,12 +1,12 @@
 class OmnistrateCtl < Formula
     desc "Omnistrate CTL command line tool"
     homepage "https://omnistrate.com"
-    version "v0.13.30"
+    version "v0.13.31"
     
-    sha_darwin_amd64 = "9114731652ed422aff8714d1110bc76222abbc1e3779ce4b72f8c0c1294f8f6e"
-    sha_darwin_arm64 = "f5768a3d509b5488fed105909d21df41baed3e5b0d9d2440b725e4e2eefc7f9e"
-    sha_linux_amd64 = "0ff49d2d5e27d9b75924f9da8e8d640efcc9b8a2ce5daa034e8cb224ab6d42c5"
-    sha_linux_arm64 = "09ecf117d4caf51866e31142c6d84579a0472970b2e7c4f591280605adcd3a09"
+    sha_darwin_amd64 = "7b5659135814c027190237996c9ca50f2f9478689052084d1d2a147aa2280096"
+    sha_darwin_arm64 = "78ffd109ee88b4cfc9f55ca2536916e3c28e7048645075de4b78d45a3fe5ec1a"
+    sha_linux_amd64 = "3b5f521e045acfd4a326567fa658fafb9e26165bffad0f8a4fe45c07138a9ee9"
+    sha_linux_arm64 = "4ab1af3fa81cc675a035d496ddc0d0c5e4d20cedacb3c749a43eea6d5f00eb14"
 
     if OS.mac?
       if Hardware::CPU.intel?


### PR DESCRIPTION
This PR updates the Omnistrate CTL Formula to version v0.13.31.
The SHA256 checksums have been updated as well.
Once the PR is merged, the new version will be available in the Omnistrate Homebrew Tap.