### PR TITLE
Update Omnistrate CTL Formula to v0.14.3

### DIFF
--- a/Formula/omnistrate-ctl.rb
+++ b/Formula/omnistrate-ctl.rb
@@ -1,12 +1,12 @@
 class OmnistrateCtl < Formula
     desc "Omnistrate CTL command line tool"
     homepage "https://omnistrate.com"
-    version "v0.13.39"
+    version "v0.14.3"
     
-    sha_darwin_amd64 = "dfca3ca33ab86bbbe17440102fe07d24e6330382276d4b04f74eabd2890533fc"
-    sha_darwin_arm64 = "02a19597c32c3aa9fcf08c01015bae552f92837dc487282dd043c426ef8b2b87"
-    sha_linux_amd64 = "41b84ec7ee0e4b11cea88c16c1cf73673dc8e38851a4c853112c50e44d2538cb"
-    sha_linux_arm64 = "0b6fc2fe753d6991430accbce032d187deb3556e5b1a61a008aaa8ee24f8e3a5"
+    sha_darwin_amd64 = "2e9ba638d6da878be64986cab939b40489a7ab4933350ed1fa03957cb7aa9497"
+    sha_darwin_arm64 = "c4673bd60ac4ee43cf65886e5a45a0f7623cf3fa84bd0366b39be50c8d71124e"
+    sha_linux_amd64 = "c4ba6b53b0144a86ae0264939eb3561c74cb4beb6eb3c19ffde20a536f30812d"
+    sha_linux_arm64 = "323f6e638e059c234ccfb175d3f04354ab3e87beb936f94d473662a72ba3fab9"
 
     if OS.mac?
       if Hardware::CPU.intel?


### PR DESCRIPTION
This PR updates the Omnistrate CTL Formula to version v0.14.3.
The SHA256 checksums have been updated as well.
Once the PR is merged, the new version will be available in the Omnistrate Homebrew Tap.