### PR TITLE
Update Omnistrate CTL Formula to v0.14.4

### DIFF
--- a/Formula/omnistrate-ctl.rb
+++ b/Formula/omnistrate-ctl.rb
@@ -1,12 +1,12 @@
 class OmnistrateCtl < Formula
     desc "Omnistrate CTL command line tool"
     homepage "https://omnistrate.com"
-    version "v0.14.3"
+    version "v0.14.4"
     
-    sha_darwin_amd64 = "2e9ba638d6da878be64986cab939b40489a7ab4933350ed1fa03957cb7aa9497"
-    sha_darwin_arm64 = "c4673bd60ac4ee43cf65886e5a45a0f7623cf3fa84bd0366b39be50c8d71124e"
-    sha_linux_amd64 = "c4ba6b53b0144a86ae0264939eb3561c74cb4beb6eb3c19ffde20a536f30812d"
-    sha_linux_arm64 = "323f6e638e059c234ccfb175d3f04354ab3e87beb936f94d473662a72ba3fab9"
+    sha_darwin_amd64 = "008add24512e1ba34a317cdd68f790a3a155aa33df0be56ca64b518bc93f6c79"
+    sha_darwin_arm64 = "a4ccddc39617c7efaea8adb323d73fc90888591a890774d34f3bb09f74913a87"
+    sha_linux_amd64 = "405d91520c9e22543a1b30b15b74a05a89c737fcbc0905b10a20db8e6b46220a"
+    sha_linux_arm64 = "8abe089f1411fdd45ce6cb943153a07dbbfe0fdf2d5e9b558c18c4848087a622"
 
     if OS.mac?
       if Hardware::CPU.intel?


### PR DESCRIPTION
This PR updates the Omnistrate CTL Formula to version v0.14.4.
The SHA256 checksums have been updated as well.
Once the PR is merged, the new version will be available in the Omnistrate Homebrew Tap.