### PR TITLE
chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/test-formula.yml
+++ b/.github/workflows/test-formula.yml
@@ -15,7 +15,7 @@ jobs:
                 os: [macos-latest, ubuntu-latest]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v6
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
             - name: Install Homebrew (Linux only)
               if: runner.os == 'Linux'


### PR DESCRIPTION
## What

Pin every third-party GitHub Action referenced in this repo (workflows + composite actions) to a full 40-character commit SHA, with the original version tag preserved as a trailing comment (e.g. `actions/checkout@<sha> # v6.0.2`).

## Why

Per [GitHub's security hardening guide for Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions), third-party actions should be pinned to a full commit SHA. Version tags and branch refs are mutable and a compromised tag (as happened with `tj-actions/changed-files` in March 2025) can give an attacker arbitrary code execution with our secrets.

## How

- Ran [`pinact`](https://github.com/suzuki-shunsuke/pinact) over `.github/workflows/` and `.github/actions/`.
- Internal org reusable workflows (omnistrate/*) intentionally left at `@master` since they are trusted.

## Tests

No source code changes. CI on this PR exercises the pinned workflows end-to-end.

---

Part of a wider rollout across active repos.