### PR TITLE
Update Omnistrate CTL Formula to v1.6.11

### DIFF
--- a/Formula/omnistrate-ctl.rb
+++ b/Formula/omnistrate-ctl.rb
@@ -1,12 +1,12 @@
 class OmnistrateCtl < Formula
     desc "Omnistrate CTL command line tool"
     homepage "https://omnistrate.com"
-    version "v1.6.8"
+    version "v1.6.11"
     
-    sha_darwin_amd64 = "a14ef9ea3dcb0d5764723cc3ce6c8b4b7262af92f60af12d0291ebfb39d1e0de"
-    sha_darwin_arm64 = "e95c6c04d6e7e721f1df2d69ff8f2c029fc29093d937e50de651a436267654e6"
-    sha_linux_amd64 = "6c5a86750a1040ba696a2d54fbd30159b1b7af523039b04d19c67b4915c92d81"
-    sha_linux_arm64 = "50ea09e83f2e8b7bf9a1b61ae37e1a93d754d253db2fb80d541260968e0543e0"
+    sha_darwin_amd64 = "553f6671f73d8d1a504a514c32cce92f41f451a43303fdf07f04d53adcd3c3a1"
+    sha_darwin_arm64 = "2990afeeebac83bff3d817e79696e97be09b143e79db7457a72be809b008a26e"
+    sha_linux_amd64 = "cfc7a99054ca442f118e535e046e234566de63bb42a475f14ccb8464333e4b23"
+    sha_linux_arm64 = "6c9fbc16874fcf548b0dfec2d6506c516c5165c231a1398392ae9c13870fd978"
 
     if OS.mac?
       if Hardware::CPU.intel?


### PR DESCRIPTION
This PR updates the Omnistrate CTL Formula to version v1.6.11.
The SHA256 checksums have been updated as well.
Once the PR is merged, the new version will be available in the Omnistrate Homebrew Tap.