### PR TITLE
Update Omnistrate CTL Formula to v1.9.5

### DIFF
--- a/Formula/omnistrate-ctl.rb
+++ b/Formula/omnistrate-ctl.rb
@@ -1,12 +1,12 @@
 class OmnistrateCtl < Formula
     desc "Omnistrate CTL command line tool"
     homepage "https://omnistrate.com"
-    version "v1.9.4"
+    version "v1.9.5"
     
-    sha_darwin_amd64 = "6970f5b1ea56d72955148d942be600bfa0a62b04e8c2b188bb16daa5716110de"
-    sha_darwin_arm64 = "c3de802f22a28a9c30d4d5e773aa4fc1d695ed8e67b222aad4874a58a3769dd5"
-    sha_linux_amd64 = "49c9fb89244237601ff4472b862a12886992933ff158588d4626014578d553f6"
-    sha_linux_arm64 = "5d47a7ae91c49c868a474abed2917d366d7b18f93296aece481a83319af8ac6a"
+    sha_darwin_amd64 = "6986221adc10dc50c181f940338362d6e849d5f080a69efa562a224fa68e5fb6"
+    sha_darwin_arm64 = "4c49cf7be5d8bf19ca33ec5a513f45e3070564fe936aee490a6316d1e214c316"
+    sha_linux_amd64 = "7d489a140156076bdc5c18c4f0c0d6b799624b37dd4625b2b68ee3c361092d58"
+    sha_linux_arm64 = "cc3fd00806be9f916af1fc80ba53317745e6d78ae8c61e5c2985361f8c13af15"
 
     if OS.mac?
       if Hardware::CPU.intel?


### PR DESCRIPTION
This PR updates the Omnistrate CTL Formula to version v1.9.5.
The SHA256 checksums have been updated as well.
Once the PR is merged, the new version will be available in the Omnistrate Homebrew Tap.